### PR TITLE
Release v1.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-se-flair",
-  "version": "1.0.2",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-se-flair",
-      "version": "1.0.2",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-se-flair",
   "displayName": "Homebridge SE Flair",
-  "version": "1.0.2",
+  "version": "1.0.11",
   "description": "Homebridge plugin for Flair.co pucks, vents, and gateways (no HVAC control)",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package version to 1.0.11
- publish package to npm using provided token

## Testing
- `npm run build`
- `pytest -q`
- `npm publish`

------
https://chatgpt.com/codex/tasks/task_e_6856107e56d4832ebc1c0b34dbea2764