### PR TITLE
Improve OAuth flow logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Run the helper script to perform the login flow. It will open a browser and auto
 npm run auth-helper
 ```
 If `refreshToken` is omitted from your config, the plugin will also trigger this browser flow on the first launch and store the token automatically.
+If no browser window appears, copy the authorization link from the logs and open it manually.
 
 ### Python helper scripts
 The optional `vent_status.py` script reads credentials from the environment variables `FLAIR_CLIENT_ID` and `FLAIR_CLIENT_SECRET` before accessing the API.

--- a/dist/platform.js
+++ b/dist/platform.js
@@ -115,6 +115,7 @@ class FlairPlatform {
                 }
             });
             server.listen(3000, () => {
+                this.log.info(`Open this URL in your browser to authorize: ${authUrl}`);
                 (0, open_1.default)(authUrl).catch(err => this.log.error('Failed to open browser', err));
                 this.log.info('Waiting for OAuth authorization in browser...');
             });

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -90,6 +90,7 @@ export class FlairPlatform implements DynamicPlatformPlugin {
         }
       });
       server.listen(3000, () => {
+        this.log.info(`Open this URL in your browser to authorize: ${authUrl}`);
         open(authUrl).catch(err => this.log.error('Failed to open browser', err));
         this.log.info('Waiting for OAuth authorization in browser...');
       });


### PR DESCRIPTION
## Summary
- print auth link when waiting for OAuth authorization
- mention manual auth link in README

## Testing
- `npm run build`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561f9fc6c4832eb6cde4d065078997