### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-se-flair",
-  "version": "1.0.11",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-se-flair",
-      "version": "1.0.11",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-se-flair",
   "displayName": "Homebridge SE Flair",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Homebridge plugin for Flair.co pucks, vents, and gateways (no HVAC control)",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package version

## Testing
- `npm run build`
- `npm publish --access public` *(fails: 404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_6857328ce090832eb16bca5eae6949c3