### PR TITLE
Add export map for upcoming npm changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "1.1.2",
   "description": "Homebridge plugin for Flair.co pucks, vents, and gateways (no HVAC control)",
   "main": "dist/index.js",
+  "type": "commonjs",
+  "exports": {
+    ".": "./dist/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "auth-helper": "ts-node src/auth-helper.ts"


### PR DESCRIPTION
## Summary
- add `type: commonjs` and export map to package.json for compatibility with npm defaults

## Testing
- `npm run build`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685739168d04832eafec53d283a15b81