### PR TITLE
Fix vent_status dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ If `refreshToken` is omitted from your config, the plugin will also trigger this
 If no browser window appears, copy the authorization link from the logs and open it manually.
 
 ### Python helper scripts
-The optional `vent_status.py` script reads credentials from the environment variables `FLAIR_CLIENT_ID` and `FLAIR_CLIENT_SECRET` before accessing the API.
+The optional `vent_status.py` script reads credentials from the environment variables `FLAIR_CLIENT_ID` and `FLAIR_CLIENT_SECRET` before accessing the API. Install dependencies with `pip install -r requirements.txt`.
+
+### npm proxy warning
+If you see `npm warn Unknown env config "http-proxy"` during `npm` commands,
+rename your proxy environment variables to `npm_config_proxy` and
+`npm_config_https_proxy`. The deprecated `http_proxy` and
+`https_proxy` variables trigger this warning in newer npm versions.
 
 ## Status
 - ✅ OAuth2 refresh token flow with automatic browser capture

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.32.0
+flair_client>=1.0.0


### PR DESCRIPTION
## Summary
- add missing dependency to requirements
- document vent_status dependencies in README
- explain how to resolve npm's `http-proxy` warning

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68573a112ecc832ea173af105c04da75