### PR TITLE
Fix lint issues and update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-se-flair",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-se-flair",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-se-flair",
   "displayName": "Homebridge SE Flair",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Homebridge plugin for Flair.co pucks, vents, and gateways (no HVAC control)",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/test_flair.py
+++ b/test_flair.py
@@ -1,8 +1,11 @@
-import requests
+"""Unit tests for Flair API helper functions."""
+
 from unittest.mock import patch, MagicMock
+import requests
 
 
 def get_access_token(client_id: str, client_secret: str) -> str:
+    """Retrieve an OAuth access token from the Flair API."""
     res = requests.post(
         "https://api.flair.co/oauth/token",
         data={
@@ -10,21 +13,25 @@ def get_access_token(client_id: str, client_secret: str) -> str:
             "client_id": client_id,
             "client_secret": client_secret,
         },
+        timeout=10,
     )
     res.raise_for_status()
     return res.json()["access_token"]
 
 
 def fetch_structures(token: str):
+    """Return the structures list using the given bearer token."""
     res = requests.get(
         "https://api.flair.co/structures",
         headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
     )
     res.raise_for_status()
     return res.json()
 
 
 def test_api_flow():
+    """Verify authentication and structure fetch logic."""
     token_resp = MagicMock(status_code=200, json=lambda: {"access_token": "T"})
     structures_resp = MagicMock(status_code=200, json=lambda: {"data": []})
     with patch("requests.post", return_value=token_resp) as mock_post, patch(
@@ -38,4 +45,5 @@ def test_api_flow():
         mock_get.assert_called_once_with(
             "https://api.flair.co/structures",
             headers={"Authorization": "Bearer T"},
+            timeout=10,
         )

--- a/vent_status.py
+++ b/vent_status.py
@@ -1,6 +1,9 @@
-from flair_api import make_client, Resource
+"""Fetch and display the current status of vents from the Flair API."""
+
 from datetime import datetime
 import os
+import sys
+from flair_api import make_client, Resource
 
 CLIENT_ID = os.getenv("FLAIR_CLIENT_ID")
 CLIENT_SECRET = os.getenv("FLAIR_CLIENT_SECRET")
@@ -43,7 +46,7 @@ client = make_client(
 structures = client.get("structures")
 if not structures:
     print("No structures found.")
-    exit()
+    sys.exit()
 
 structure = structures[0]
 print(f"\n✅ Structure: {structure.attributes['name']} (ID: {structure.id})")
@@ -52,7 +55,7 @@ print(f"\n✅ Structure: {structure.attributes['name']} (ID: {structure.id})")
 vents = structure.get_rel("vents")
 if not vents:
     print("No vents found.")
-    exit()
+    sys.exit()
 
 for vent in vents:
     name = vent.attributes.get("name")


### PR DESCRIPTION
## Summary
- improve imports and exit handling in `vent_status.py`
- add docstrings and timeouts in `test_flair.py`
- bump package version to 1.1.3

## Testing
- `npm run build`
- `pytest -q`
- `pylint vent_status.py test_flair.py`
- `npm publish --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68573da52678832e815f61b781ee61c1