### PR TITLE
Improve config UI layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Add the following to your Homebridge `config.json` (or use Homebridge UI):
   "includeGateways": true
 }
 ```
+When using the Homebridge UI, your OAuth credentials now appear in a **Flair API Credentials** section, with polling and accessory options grouped under **Device Options**.
 `pollInterval` controls how often the plugin refreshes device state from Flair.
 If omitted, it defaults to `300` seconds. The `include*` options let you disable adding pucks, vents, or gateways; all default to `true` following the Flair API defaults.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -24,13 +24,15 @@
       "refreshToken": {
         "title": "Refresh Token",
         "type": "string",
-        "description": "Optional. If omitted, a browser flow will run on startup and token will be stored securely"
+        "description": "Optional. If omitted, a browser flow will run on startup and token will be stored securely",
+        "markdownDescription": "Leave blank to automatically open a browser for authorization on first launch."
       },
       "pollInterval": {
         "title": "Poll Interval",
         "type": "number",
         "default": 300,
-        "description": "How often to refresh device state (seconds)"
+        "description": "How often to refresh device state (seconds)",
+        "minimum": 60
       },
       "includePucks": {
         "title": "Add Pucks",
@@ -56,12 +58,19 @@
   "layout": [
     {
       "type": "fieldset",
-      "title": "Flair API OAuth2 Authentication",
+      "title": "Flair API Credentials",
       "expandable": false,
       "items": [
         "clientId",
         "clientSecret",
-        "refreshToken",
+        "refreshToken"
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Device Options",
+      "expandable": false,
+      "items": [
         "pollInterval",
         "includePucks",
         "includeVents",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-se-flair",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-se-flair",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-se-flair",
   "displayName": "Homebridge SE Flair",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Homebridge plugin for Flair.co pucks, vents, and gateways (no HVAC control)",
   "main": "dist/index.js",
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- document new sections in Homebridge UI configuration
- tweak config schema to group OAuth credentials and options
- bump version to 1.1.4

## Testing
- `npm run build`
- `pytest -q`
- `flake8 vent_status.py test_flair.py`

------
https://chatgpt.com/codex/tasks/task_e_685840b92ddc832e97e4a88253f2897b