### PR TITLE
Add Homebridge UI button for OAuth helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Run the helper script to perform the login flow. It will open a browser and auto
 ```bash
 npm run auth-helper
 ```
+You can also click **Run OAuth Helper** in the Homebridge UI which executes the same command.
+
 If `refreshToken` is omitted from your config, the plugin will also trigger this browser flow on the first launch and store the token automatically.
 If no browser window appears, copy the authorization link from the logs and open it manually.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -77,5 +77,12 @@
         "includeGateways"
       ]
     }
+  ],
+  "buttons": [
+    {
+      "label": "Run OAuth Helper",
+      "command": "npm run auth-helper",
+      "tooltip": "Open browser and store refresh token"
+    }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-se-flair",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-se-flair",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-se-flair",
   "displayName": "Homebridge SE Flair",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Homebridge plugin for Flair.co pucks, vents, and gateways (no HVAC control)",
   "main": "dist/index.js",
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- document OAuth helper button in the README
- expose an OAuth helper command in `config.schema.json`
- bump package version to 1.1.6

## Testing
- `flake8 src test_flair.py vent_status.py`
- `pytest -q`
- `npm run build`
- `npm publish --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_685846bd1c58832eacf8e63c3a06cbd4