### PR TITLE
Bump version to 1.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-se-flair",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-se-flair",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-se-flair",
   "displayName": "Homebridge SE Flair",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Homebridge plugin for Flair.co pucks, vents, and gateways (no HVAC control)",
   "main": "dist/index.js",
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- bump version to 1.1.7

## Testing
- `python -m pytest -q`
- `flake8 test_flair.py --isolated`
- `npm publish`

------
https://chatgpt.com/codex/tasks/task_e_68584de850ac832eb18f82cc29839c74